### PR TITLE
Fix render level passing bug in Segment Render

### DIFF
--- a/segment_renderer/renderer.cpp
+++ b/segment_renderer/renderer.cpp
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
     }
 
     if (project_regions.empty()) {
-      RenderRegionsRandomColor(FLAGS_render_level,
+      RenderRegionsRandomColor(absolute_level,
                                true,     // With boundaries.
                                false,    // No shape moments.
                                segmentation,


### PR DESCRIPTION
Absolute level was previously being worked out (on line 265, using the --render_level flag), but not being passed to RenderRegionsRandomColour.

Instead, FLAGS_render_level (in the range [0..1]) was being passed, which is the wrong value to use (unless --render_level was set to 0). 

This commit fixes this issue by passing absolute_level rather than FLAGS_render_level to the RenderRegionsRandomColor call.

*(I'm 99% sure this is a bug, apologies if it's just that I've missed something..!)*